### PR TITLE
fix: java.util.Collections doesn't work when treating Maps as Records

### DIFF
--- a/core/src/test/java/org/bsc/java2typescript/MemberClassTest.java
+++ b/core/src/test/java/org/bsc/java2typescript/MemberClassTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
  * @author bsorrentino
  *
  */
-public class MemeberClassTest extends AbstractConverterTest {
+public class MemberClassTest extends AbstractConverterTest {
 
     
     @Test

--- a/processor/src/main/java/org/bsc/processor/TypescriptProcessor.java
+++ b/processor/src/main/java/org/bsc/processor/TypescriptProcessor.java
@@ -46,7 +46,7 @@ public class TypescriptProcessor extends AbstractProcessorEx {
 
       // Utility class(s)
       TSType.of(java.util.stream.Collectors.class).setExport(true),
-      TSType.of(java.util.Collections.class).setExport(true),
+      // TSType.of(java.util.Collections.class).setExport(true), // Requires smarter typing of java.util.Map (only treat it as a record if the type of the key is compatible)
 
       // Native functional interface(s)
       TSType.of(java.util.function.Function.class).setAlias("Func"),


### PR DESCRIPTION
java.util.Collections methods which take a Map as a parameter don't work if we just treat all Maps as Records (because the type fo the key may not be compatible with a Record). For now, just remove it from the default generated types; ideally we'd need to handle the Map type in a smarter way.