### PR TITLE
chore: Replace deprecated reference path with import

### DIFF
--- a/processor/src/main/java/org/bsc/processor/TypescriptProcessor.java
+++ b/processor/src/main/java/org/bsc/processor/TypescriptProcessor.java
@@ -141,7 +141,7 @@ public class TypescriptProcessor extends AbstractProcessorEx {
           .sorted()
           .forEach(wD_append);
 
-      wT_append.accept(String.format("/// <reference path=\"%s\"/>\n\n", definitionsFile));
+      wT_append.accept(String.format("import \"%s\"\n\n", definitionsFile));
 
       types.stream()
           .filter(t -> t.isExport())


### PR DESCRIPTION
Deprecated in TypeScript 5.0, no longer works in 5.5.